### PR TITLE
Bug fix for using mulitple clusters settings.

### DIFF
--- a/helper/ClusterHelper.php
+++ b/helper/ClusterHelper.php
@@ -8,6 +8,10 @@
 		@copyright All rights reserved - 2011
 	*/
 
+	require('include/autoload.php');	
+	
+	use phpcassa\SystemManager;
+	
 	class ClusterHelper {		
 		private $cassandra_clusters = array();
 		


### PR DESCRIPTION
# Briefing
## Issue

When you set multiple clusters in your  include/conf.inc.php, 
it causes a php fatal error as shown below:

> PHP Fatal error:  Class 'SystemManager' not found in /PATH/TO/YOUR/APP/Cassandra-Cluster-Admin/helper/ClusterHelper.php on line 41
## Workaround

I added the following lines in helper/ClusterHelper.php,
to make this helper able to load  SystemMager class.

>   require('include/autoload.php');    
> 
>   use phpcassa\SystemManager;
## Comments

I don't think this is the best way to solve the problem, 
but at lease it worked and I needed to make it work AQAP so I wrote this simple dirty patch.

Regards.
