### PR TITLE
Fixed the order of Value and Actions columns for Browse Data view

### DIFF
--- a/views/columnfamily_browse_data_row.php
+++ b/views/columnfamily_browse_data_row.php
@@ -3,8 +3,8 @@
             $uuid = @unserialize($key)->string;
             $key = $uuid ? $uuid : $key;
             echo htmlentities($key,ENT_COMPAT,'UTF-8');
-        ?></td>
-	<td>
+        ?>
+	</td>
 	<td>
 		<?php 
 			switch ($comparator_type) {


### PR DESCRIPTION
Removed illegal `<td>` to display Value and Actions columns values in the proper order for the Browse Data view (right now the values are shifted into the right resulting in empty Value column and actual Value value being in the Actions column).
